### PR TITLE
Update requirements, use ruff, update .md files, add dependabot

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-ignore = E501
-exclude = .git,__pycache__,.ipynb_checkpoints
-max-line-length = 90

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "pip" 
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9]
+        python-version: [3.11, 3.12]
     steps:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,14 @@
-
 repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+    rev: v0.12.5
+    hooks:
+      # Run the linter.
+      - id: ruff-check
+      # Run the formatter.
+      - id: ruff-format
   - repo: https://github.com/kynan/nbstripout
     rev: 0.8.1
     hooks:
-      - id: nbstripout
-        files: ".ipynb"
-  - repo: https://github.com/psf/black
-    rev: 25.1.0
-    hooks:
-    - id: black
+    - id: nbstripout
+  

--- a/README.md
+++ b/README.md
@@ -30,23 +30,30 @@ If you want to run the test module manually, execute
 `python -m pytest`  
 in the `src/` directory.
 
-The repository contains a configuration file for `pre-commit` hooks. To activate the hooks, run `pre-commit install`. This will then provide a check whenever you commit changes to the repository: In particular, the linter `flake8` will check all Python source files and iPython notebooks, and `black` will reformat all Python source files and iPython notebooks to adhere to the PEP rules.
-If the files are reformatted, or `flake8` still detects further issues, the commit will fail as the files are changed. You need to stage these changed files again using the `git add` command and the commit to the repository again. Committing these the second time should then work and you can then push to the remote. 
+The repository contains a configuration file for `pre-commit` hooks. To activate the hooks, run `pre-commit install`. This will then provide a check whenever you commit changes to the repository: In particular, `ruff` linter will check all Python source files and iPython notebooks, and `ruff` formatter will reformat all Python source files and iPython notebooks to adhere to the PEP rules.
+If the files are reformatted, or `ruff` still detects further issues, the commit will fail as the files are changed. You need to stage these changed files again using the `git add` command and the commit to the repository again. Committing these the second time should then work and you can then push to the remote. 
 
 ## github actions
 
 This repository contains a github action in `./github/workflows/`. This will run linting, unit tests and update the documentation upon push to the master branch and upon pull request. The action can also be run manually in the "Actions" tab on the github website.
 
 ### Linting
-The linter (in this case, `flake8` will point out potential bugs, errors, styling issues, and suspicious code.
+The linter (in this case, `ruff`) will point out potential bugs, errors, styling issues, and suspicious code.
 
 ### Testing
 You should always test your code against a reference. In this template, we use `pytest` which is a popular option that is very versatile.
 
 So far, only *unit tests* are included in the code template (that is, tests of a specific component of the software), but as you develop your software, you should also add `integration tests` that check the overall behaviour of your code.
 
-In the github action, the tests are performed under ubuntu, windows and mac operating systems to ensure that the code runs in different environments. Also, two different python versions are tested right now, 3.8 and 3.9.
+In the github action, the tests are performed under ubuntu, windows and mac operating systems to ensure that the code runs in different environments. Also, two different python versions are tested right now, 3.11 and 3.12.
 
 ### Source Code Documentation: Functions, modules, classes, ...
-The documentation should be updated as you update your code. Include appropriate method descriptions in your code and `sphinx` will update the documentation html for your functions, classes, etc. The documentation is build using `make html` in the `doc` folder. On your local machine, you can navigate to `doc/build/index.html` and check the styling.
+The documentation should be updated as you update your code. Include appropriate method descriptions in your code and `sphinx` will update the documentation html for your functions, classes, etc. The documentation is build using `make html` in the `doc` folder. On your local machine, you can navigate to `doc/build/html/index.html` and check the styling.
 If your code is in a public repository, you can push your sphinx documentation to [Read the docs](https://ssc-hd-python-project-template.readthedocs.io/en/latest/?).
+
+## Dependabot
+Dependabot on GitHub is a built‑in service that helps you keep your dependencies secure and up‑to‑date. When it detects a vulnerable or outdated package, Dependabot automatically opens a Pull Request (PR) with the recommended update. After reviewing and verifying the changes (e.g. via tests), you can merge the PR.
+
+To enable Dependabot in your repository, follow [this guide](https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide#enabling-dependabot-for-your-repository). The configuration file for Dependabot can be found in the `./github/` directory.
+
+

--- a/doc/input.md
+++ b/doc/input.md
@@ -3,14 +3,14 @@ Here goes a description of the input required for your program.
 # Program input
 
 The program options can be displayed by running
-`python ./src/main.py -h`  
+`python ./src/mypackage/main.py -h`  
 
 This will return the possible input options and type of parameters. 
 
-For example, to calculate the side length of a square with the same area as a circle of radius r, you would run  
-`python ./src/main.py -o square -r 4`  
+For example, to calculate the side length of a square with the same area as a circle of radius $r$ (e.g. $r = 4$), you would run  
+`python ./src/mypackage/main.py -o square -r 4`  
 
 For the side length of a pentagon, you would provide  
-`python ./src/main.py -o pentagon -r 4`  
+`python ./src/mypackage/main.py -o pentagon -r 4`  
 
 The program will then return the side length of the selected object.

--- a/doc/method.md
+++ b/doc/method.md
@@ -1,8 +1,10 @@
 Here goes a description of the scientific method and explanation of the keywords in terms of a method reference.
 
-This is to use latex-style equations in github markdown - unfortunatly it is not as nifty as i.e. jupyter:
+This is to use latex-style equations in github markdown:
 
-<img src="https://render.githubusercontent.com/render/math?math=e^{i \pi} = -1">
+$$
+e^{i \pi} = -1
+$$
 
 # Methods
 
@@ -10,13 +12,19 @@ The program uses three functions to calculate the desired values.
 
 ## The area of a circle
 The area is calculated using 
-<img src="https://render.githubusercontent.com/render/math?math=A = \pi r^2">
+$$
+A = \pi r^2
+$$
 
 ## The side length of a square
 The side length of a square with given area is calculated using 
-<img src="https://render.githubusercontent.com/render/math?math=a = \sqrt{A}">
+$$
+a = \sqrt{A}
+$$
 
 
 ## The side length of a pentagon
 The side length of a pentagon with given area is calculated using 
-<img src="https://render.githubusercontent.com/render/math?math=a = \sqrt{\frac{4}{\sqrt{5(5+2*\sqrt{5})}} \cdot A}">
+$$
+a = \sqrt{\frac{4}{\sqrt{5(5+2*\sqrt{5})}} \cdot A}
+$$

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-numpy==1.23.1
-click>=8.0.0
-sphinx==5.1.1
-myst-parser==0.18.0
+numpy==2.3.2
+click==8.2.1
+sphinx==8.2.3
+myst-parser==4.0.1
 sphinxcontrib-napoleon==0.7
-pytest==7.1.2
-black==24.3.0
-nbstripout==0.6.0
-flake8==4.0.1
+pytest==8.4.1
+nbstripout==0.8.1
+ruff==0.12.7
+pre-commit==4.2.0

--- a/src/mypackage/transform.py
+++ b/src/mypackage/transform.py
@@ -13,9 +13,7 @@ def area_circ(r_in):
     area_out = np.pi * r_in**2
     print(
         "The area of a circle with radius r = {:3.2f}cm \
-        is A = {:4.2f}cm2.".format(
-            r_in, area_out
-        )
+        is A = {:4.2f}cm2.".format(r_in, area_out)
     )
     return area_out
 
@@ -28,9 +26,7 @@ def side_square(area_in):
     a_out = np.sqrt(area_in)
     print(
         "The side length of a square with area = {:4.2f}cm2 \
-        is a = {:3.8f}cm.".format(
-            area_in, a_out
-        )
+        is a = {:3.8f}cm.".format(area_in, a_out)
     )
     return a_out
 
@@ -44,8 +40,6 @@ def side_pentagon(area_in):
     a_out = np.sqrt(area_in * factor)
     print(
         "The side length of a pentagon with area = {:4.2f}cm2 \
-        is a = {:3.8f}cm.".format(
-            area_in, a_out
-        )
+        is a = {:3.8f}cm.".format(area_in, a_out)
     )
     return a_out


### PR DESCRIPTION
- [x] update requirements.txt (update lib versions, use `ruff` instead of `flake8` and `black`)
- [x] update `ruff` in `pre-commit-config.yaml`
- [x] use new python versions
- [x] add dependabot
- [x] update .md files accordingly

Remaining issue: cross-ref links currently work on GitHub page and not in Sphinx. This hasn’t been added to the issue list since we may move from Sphinx to MkDocs in the future.